### PR TITLE
vim-checkbox-movements: implemented

### DIFF
--- a/dev/checkbox_input.sh
+++ b/dev/checkbox_input.sh
@@ -146,10 +146,6 @@ on_checkbox_input_ascii() {
   esac
 }
 
-_null() {
-  :
-}
-
 _checkbox_input() {
   local i
   local j
@@ -190,7 +186,7 @@ _checkbox_input() {
     tput cuu1
   done
 
-  on_keypress on_checkbox_input_up on_checkbox_input_down on_checkbox_input_space on_checkbox_input_enter _null _null on_checkbox_input_ascii
+  on_keypress on_checkbox_input_up on_checkbox_input_down on_checkbox_input_space on_checkbox_input_enter on_default on_default on_checkbox_input_ascii
 }
 
 checkbox_input() {

--- a/dev/checkbox_input.sh
+++ b/dev/checkbox_input.sh
@@ -137,6 +137,19 @@ remove_checkbox_instructions() {
   fi
 }
 
+# for vim movements
+on_checkbox_input_ascii() {
+  local key=$1
+  case $key in
+    "j" ) on_checkbox_input_down;;
+    "k" ) on_checkbox_input_up;;
+  esac
+}
+
+_null() {
+  :
+}
+
 _checkbox_input() {
   local i
   local j
@@ -177,7 +190,7 @@ _checkbox_input() {
     tput cuu1
   done
 
-  on_keypress on_checkbox_input_up on_checkbox_input_down on_checkbox_input_space on_checkbox_input_enter
+  on_keypress on_checkbox_input_up on_checkbox_input_down on_checkbox_input_space on_checkbox_input_enter _null _null on_checkbox_input_ascii
 }
 
 checkbox_input() {

--- a/dist/checkbox_input.sh
+++ b/dist/checkbox_input.sh
@@ -239,6 +239,19 @@ remove_checkbox_instructions() {
   fi
 }
 
+# for vim movements
+on_checkbox_input_ascii() {
+  local key=$1
+  case $key in
+    "j" ) on_checkbox_input_down;;
+    "k" ) on_checkbox_input_up;;
+  esac
+}
+
+_null() {
+  :
+}
+
 _checkbox_input() {
   local i
   local j
@@ -279,7 +292,7 @@ _checkbox_input() {
     tput cuu1
   done
 
-  on_keypress on_checkbox_input_up on_checkbox_input_down on_checkbox_input_space on_checkbox_input_enter
+  on_keypress on_checkbox_input_up on_checkbox_input_down on_checkbox_input_space on_checkbox_input_enter _null _null on_checkbox_input_ascii
 }
 
 checkbox_input() {

--- a/dist/checkbox_input.sh
+++ b/dist/checkbox_input.sh
@@ -248,10 +248,6 @@ on_checkbox_input_ascii() {
   esac
 }
 
-_null() {
-  :
-}
-
 _checkbox_input() {
   local i
   local j
@@ -292,7 +288,7 @@ _checkbox_input() {
     tput cuu1
   done
 
-  on_keypress on_checkbox_input_up on_checkbox_input_down on_checkbox_input_space on_checkbox_input_enter _null _null on_checkbox_input_ascii
+  on_keypress on_checkbox_input_up on_checkbox_input_down on_checkbox_input_space on_checkbox_input_enter on_default on_default on_checkbox_input_ascii
 }
 
 checkbox_input() {

--- a/dist/inquirer.sh
+++ b/dist/inquirer.sh
@@ -238,6 +238,19 @@ remove_checkbox_instructions() {
   fi
 }
 
+# for vim movements
+on_checkbox_input_ascii() {
+  local key=$1
+  case $key in
+    "j" ) on_checkbox_input_down;;
+    "k" ) on_checkbox_input_up;;
+  esac
+}
+
+_null() {
+  :
+}
+
 _checkbox_input() {
   local i
   local j
@@ -278,7 +291,7 @@ _checkbox_input() {
     tput cuu1
   done
 
-  on_keypress on_checkbox_input_up on_checkbox_input_down on_checkbox_input_space on_checkbox_input_enter
+  on_keypress on_checkbox_input_up on_checkbox_input_down on_checkbox_input_space on_checkbox_input_enter _null _null on_checkbox_input_ascii
 }
 
 checkbox_input() {

--- a/dist/inquirer.sh
+++ b/dist/inquirer.sh
@@ -247,10 +247,6 @@ on_checkbox_input_ascii() {
   esac
 }
 
-_null() {
-  :
-}
-
 _checkbox_input() {
   local i
   local j
@@ -291,7 +287,7 @@ _checkbox_input() {
     tput cuu1
   done
 
-  on_keypress on_checkbox_input_up on_checkbox_input_down on_checkbox_input_space on_checkbox_input_enter _null _null on_checkbox_input_ascii
+  on_keypress on_checkbox_input_up on_checkbox_input_down on_checkbox_input_space on_checkbox_input_enter on_default on_default on_checkbox_input_ascii
 }
 
 checkbox_input() {


### PR DESCRIPTION
added a new function to interpret ascii keys in the checkbox file, if
the key is j or k it is remapped to the up/down function