### PR TITLE
Solution to line wraps issue#2

### DIFF
--- a/dist/checkbox_input.sh
+++ b/dist/checkbox_input.sh
@@ -154,7 +154,7 @@ select_indices() {
 
 
 on_checkbox_input_up() {
-  remove_checkbox_instructions
+  #remove_checkbox_instructions
   tput cub "$(tput cols)"
 
   if [ "${_checkbox_selected[$_current_index]}" = true ]; then
@@ -184,7 +184,7 @@ on_checkbox_input_up() {
 }
 
 on_checkbox_input_down() {
-  remove_checkbox_instructions
+  #remove_checkbox_instructions
   tput cub "$(tput cols)"
 
   if [ "${_checkbox_selected[$_current_index]}" = true ]; then
@@ -250,7 +250,7 @@ on_checkbox_input_enter() {
 }
 
 on_checkbox_input_space() {
-  remove_checkbox_instructions
+  #remove_checkbox_instructions
   tput cub "$(tput cols)"
   tput el
   if [ "${_checkbox_selected[$_current_index]}" = true ]; then

--- a/dist/inquirer.sh
+++ b/dist/inquirer.sh
@@ -153,7 +153,7 @@ select_indices() {
 
 
 on_checkbox_input_up() {
-  remove_checkbox_instructions
+  #remove_checkbox_instructions
   tput cub "$(tput cols)"
 
   if [ "${_checkbox_selected[$_current_index]}" = true ]; then
@@ -183,7 +183,7 @@ on_checkbox_input_up() {
 }
 
 on_checkbox_input_down() {
-  remove_checkbox_instructions
+  #remove_checkbox_instructions
   tput cub "$(tput cols)"
 
   if [ "${_checkbox_selected[$_current_index]}" = true ]; then
@@ -249,7 +249,7 @@ on_checkbox_input_enter() {
 }
 
 on_checkbox_input_space() {
-  remove_checkbox_instructions
+  #remove_checkbox_instructions
   tput cub "$(tput cols)"
   tput el
   if [ "${_checkbox_selected[$_current_index]}" = true ]; then

--- a/examples/checkbox_input_example.sh
+++ b/examples/checkbox_input_example.sh
@@ -18,4 +18,4 @@ checkbox_input "Which hawker centres do you prefer?" hawker_centres selected_haw
 drinks=( 'Teh' 'Teh Ping Gao Siu Dai' 'Kopi O' 'Yuan Yang' )
 checkbox_input "Which drinks do you prefer?" drinks selected_drinks
 echo "Preferred Hawker Centres: $(join selected_hawkers)"
-echo "Preferred Drinks: $(join drinks)"
+echo "Preferred Drinks: $(join selected_drinks)"


### PR DESCRIPTION
After lot of debugging, I found that re-rendering checkbox_list is not worth as it involves many changes (surely can be done). `remove_checkbox_instructions` is the culprit and also the presence of the message `(Press <space> to select, <enter> to finalize)` till the end is not a bad thing. This made me to give this solution. I hope this is good, If commenting remove_checkbox_instructions has any other impact (which missed my testing), let me know. I can re-render the text on `_first_keystroke`. 