### PR TITLE
feat: added default value for text_input

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Usage: checkbox_input_indices [prompt] [array] [selected_indices_output]
 ![Text Input Example](demos/text_input.gif "Text Input Example")
 
 ```sh
-Usage: text_input [prompt] [output_variable] [regex_string (Optional)] [failed_validation_prompt (Optional)] [validator_function (Optional)]
+Usage: text_input [prompt] [output_variable] [default_value (Optional)] [failed_validation_prompt (Optional)] [validator_function (Optional)]
 ```
 
 ### [Contributors](https://github.com/tanhauhau/Inquirer.sh/blob/master/CONTRIBUTORS.md)

--- a/dist/list_input.sh
+++ b/dist/list_input.sh
@@ -151,7 +151,15 @@ select_indices() {
 
 
 
-
+# Support VIM hjkl move
+on_list_input_ascii() {
+  key=$1
+  if [[ $key == 'k' || $key == 'K' || $key == 'h' || $key == 'H' ]]; then
+    on_list_input_up
+  elif [[ $key == 'j' || $key == 'J' || $key == 'l' || $key == 'L' ]]; then
+    on_list_input_down
+  fi
+}
 
 on_list_input_up() {
   remove_list_instructions
@@ -263,7 +271,7 @@ _list_input() {
     tput cuu1
   done
 
-  on_keypress on_list_input_up on_list_input_down on_list_input_enter_space on_list_input_enter_space
+  on_keypress on_list_input_up on_list_input_down on_list_input_enter_space on_list_input_enter_space on_list_input_up on_list_input_down on_list_input_ascii on_list_input_up
 
 }
 

--- a/examples/text_input_example.sh
+++ b/examples/text_input_example.sh
@@ -13,4 +13,6 @@ PARENT_DIR=$(dirname "$DIR")
 source $PARENT_DIR/dist/text_input.sh
 
 text_input "What's your first name" name
-echo "Hello $name"
+text_input "Gender" gender "Male"
+
+echo "Hello $name ($gender)"


### PR DESCRIPTION
1. Added `default_value` support. it would be very necessary if we could have a default value for a text input. And `Inquirer.js` have the default value option.
2. Changed text_input parameter `regex_string` to `default_value`. Because we also have `validator_function`, if we want to do a regexp check, then we can do it there.